### PR TITLE
Tweak demo to hide complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ POC for No-Code Platform
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Running the demo
+
+To start the front end: `npm start`. 
+ - You may need to install react-scripts first: `npm i react-scripts`
+
+To start the back end: navigate to `backend` directory and run `python3 main.py`
+ - You will need to update `main.py` with the correct `host`, `port`, and `auth`
+ - You may need a VPN connection for your endpoint
+ - You may need to `pip3 install` the following:
+   - `flask`
+   - `asgiref` (needed for flask async)
+   - `flask_cors`
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/App.js
+++ b/src/App.js
@@ -28,7 +28,7 @@ function App() {
       <div className="center">
         {/* <input type="button" className='button' value="Upload Model" onClick={()=>{setisrendered(true)}} />
     {isrendered&&<UploadModel/>} */}
-       <UploadModel/>
+        <UploadModel/>
         <GetModel />
         <LoadModel />
         <CreatePipeline />

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { UploadModel } from './UploadModel';
 import { GetModel } from './GetModel';
 import React, { useState } from 'react';
 import { LoadModel } from './LoadModel';
+import { GetModel2 } from './GetModel2';
 import { CreatePipeline } from './CreatePipeline';
 import { CreateIndex } from './CreateIndex';
 import { ReindexModel } from './ReindexModel';
@@ -26,11 +27,25 @@ function App() {
   return (
     <div className="container">
       <div className="center">
+        Scrappy Demo
+        <br />
+        <br />
+        Each step below indicates a "module" that will be linked by the drag-and-drop GUI. Output from one becomes input to another.
+        <br />
+        <br />
+        We will link to a custom pretrained model from Huggingface using ml-commons Model-serving framework and populate a vector DB to enable neural search.
+        <br />
+        <br />
+        All the copy/paste will eventually be automated in the AI workflow.
+        <hr />
+        <br />
+        <br />
         {/* <input type="button" className='button' value="Upload Model" onClick={()=>{setisrendered(true)}} />
     {isrendered&&<UploadModel/>} */}
         <UploadModel/>
         <GetModel />
         <LoadModel />
+        <GetModel2 />
         <CreatePipeline />
         <CreateIndex />
         <ReindexModel />

--- a/src/CreateIndex.jsx
+++ b/src/CreateIndex.jsx
@@ -28,6 +28,9 @@ class CreateIndex extends React.Component {
         
         return (
             <div className="card text-center m-3" style={{marginBottom: "25%"}}>
+                Create an index to store vector DB
+                <br />
+                <br />
                 <input
                     type="text"
                     // value={this.state.value}

--- a/src/CreatePipeline.jsx
+++ b/src/CreatePipeline.jsx
@@ -28,6 +28,9 @@ class CreatePipeline extends React.Component {
         
         return (
             <div className="card text-center m-3" style={{marginBottom: "25%"}}>
+                Use this model ID to configure neural search with search pipelines
+                <br />
+                <br />
                 <input
                     type="text"
                     // value={this.state.value}

--- a/src/GetModel.jsx
+++ b/src/GetModel.jsx
@@ -29,6 +29,9 @@ class GetModel extends React.Component {
         
         return (
             <div className="card text-center m-3" style={{marginBottom: "30%"}}>
+                Query this task ID until task is complete.
+                <br />
+                <br />
                 <input
                     type="text"
                     // value={this.state.value}

--- a/src/GetModel2.jsx
+++ b/src/GetModel2.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-class SearchModel extends React.Component {
+class GetModel2 extends React.Component {
     constructor(props) {
         super(props);
 
         this.state = {
             input: null,
-            index: null
+            modelId: null
         };
     }
 
@@ -19,19 +19,19 @@ class SearchModel extends React.Component {
             method: 'GET',
             headers: { 'Content-Type': 'application/json' }
         };
-        fetch('http://127.0.0.1:5000/search/'+this.state.input, requestOptions)
+        fetch('http://127.0.0.1:5000/model/'+this.state.input, requestOptions)
             .then(response => response.json())
-            .then(data => this.setState({ index: data.hits.hits }));
+            .then(data => this.setState({ modelId: data.model_id }));
     }
 
     render() {
-        const { index } = this.state;
+        const { modelId } = this.state;
         
         return (
             <div className="card text-center m-3" style={{marginBottom: "30%"}}>
-                Query the Vector DB!
+                Query this task ID until task is complete.
                 <br />
-                <br />                
+                <br />
                 <input
                     type="text"
                     // value={this.state.value}
@@ -39,19 +39,15 @@ class SearchModel extends React.Component {
                 />
                 <input
                     type="button"
-                    value="Get Vectors"
+                    value="Get Model Id"
                     style={{marginLeft: "10%"}}
                     onClick={this.handleClick.bind(this)}
                 />
-                <p>name vectors:
-                {index && index.map((value) => (
-                    <li>{value._source.name}: <small>{value._source.name_v}</small></li>
-                    ))}
-                </p>
+                <p>Model Id: {modelId}</p>
 
             </div>
         );
     }
 }
 
-export { SearchModel }; 
+export { GetModel2 }; 

--- a/src/LoadModel.jsx
+++ b/src/LoadModel.jsx
@@ -30,6 +30,9 @@ class LoadModel extends React.Component {
         
         return (
             <div className="card text-center m-3" style={{marginBottom: "30%"}}>
+                Load the model by ID
+                <br />
+                <br />
                 <input
                     type="text"
                     // value={this.state.value}

--- a/src/ReindexModel.jsx
+++ b/src/ReindexModel.jsx
@@ -29,6 +29,9 @@ class ReindexModel extends React.Component {
         
         return (
             <div className="card text-center m-3" style={{marginBottom: "30%"}}>
+                Convert "solarsystem" index to vector DB
+                <br />
+                <br />
                 <input
                     type="text"
                     // value={this.state.value}

--- a/src/UploadModel.jsx
+++ b/src/UploadModel.jsx
@@ -5,12 +5,25 @@ class UploadModel extends React.Component {
         super(props);
 
         this.state = {
-            taskId: null
+            taskId: null,
+            body: {
+                "name": "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+                "version": "1.0.1",
+                "description": "This is a sentence-transformers model: It maps sentences & paragraphs to a 384 dimensional dense vector space and can be used for tasks like clustering or semantic search.",
+                "model_task_type": "TEXT_EMBEDDING",
+                "model_format": "TORCH_SCRIPT",
+                "model_content_size_in_bytes": 488135181,
+                "model_content_hash_value": "a2ae3c4f161bd8e5a99a19ba5589443d33a120bb2bd67aa9da102c8b201f1277",
+                "model_config": {
+                  "model_type": "bert",
+                  "embedding_dimension": 384,
+                  "framework_type": "sentence_transformers",
+                  "all_config": "{\"_name_or_path\":\"old_models/paraphrase-multilingual-MiniLM-L12-v2/0_Transformer\",\"architectures\":[\"BertModel\"],\"attention_probs_dropout_prob\":0.1,\"gradient_checkpointing\":false,\"hidden_act\":\"gelu\",\"hidden_dropout_prob\":0.1,\"hidden_size\":384,\"initializer_range\":0.02,\"intermediate_size\":1536,\"layer_norm_eps\":1e-12,\"max_position_embeddings\":512,\"model_type\":\"bert\",\"num_attention_heads\":12,\"num_hidden_layers\":12,\"pad_token_id\":0,\"position_embedding_type\":\"absolute\",\"transformers_version\":\"4.7.0\",\"type_vocab_size\":2,\"use_cache\":true,\"vocab_size\":250037}"
+                },
+                "created_time": 1676326534702,
+                "url": "https://artifacts.opensearch.org/models/ml-models/huggingface/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2/1.0.1/torch_script/sentence-transformers_paraphrase-multilingual-MiniLM-L12-v2-1.0.1-torch_script.zip"
+              }
         };
-    }
-
-    handleChange = event => {
-        this.setState({ input: event.target.value });
     }
 
     handleClick() {
@@ -18,7 +31,7 @@ class UploadModel extends React.Component {
         const requestOptions = {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify( this.state.input )
+            body: JSON.stringify( this.state.body )
         };
         fetch('http://127.0.0.1:5000/', requestOptions)
             .then(response => response.json())
@@ -29,11 +42,14 @@ class UploadModel extends React.Component {
         const { taskId } = this.state;
         return (
             <div style={{marginBottom: "25%"}}>
-                <textarea
-                    rows={20}
-                    cols={100}
-                    onChange={this.handleChange}
-                />
+                <label>
+                    Select a model to upload:
+                    <select name="selectedModel">
+                    <option value="a-model">A model</option>
+                    <option value="paraphrase">paraphrase-multilingual-MiniLM-L12-v2</option>
+                    <option value="another-model">Another model</option>
+                    </select>
+                </label>
                 <input
                     type="button"
                     value="Upload Model"

--- a/src/UploadModel.jsx
+++ b/src/UploadModel.jsx
@@ -42,14 +42,12 @@ class UploadModel extends React.Component {
         const { taskId } = this.state;
         return (
             <div style={{marginBottom: "25%"}}>
-                <label>
-                    Select a model to upload:
-                    <select name="selectedModel">
+                Select a model to upload:
+                <select name="selectedModel">
                     <option value="a-model">A model</option>
                     <option value="paraphrase">paraphrase-multilingual-MiniLM-L12-v2</option>
                     <option value="another-model">Another model</option>
-                    </select>
-                </label>
+                </select>
                 <input
                     type="button"
                     value="Upload Model"


### PR DESCRIPTION
Adds commentary to the top of the page for context setting

Hardcodes the JSON model linking text and shows a (useless) drop-down.

Duplicates the get-model so there's no backtracking in the workflow